### PR TITLE
racket -> scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "racket_rs"
+name = "scheme_rs"
 version = "0.1.0"
 dependencies = [
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "racket_rs"
+name = "scheme_rs"
 version = "0.1.0"
 edition = "2024"
 
@@ -12,6 +12,6 @@ doctest = false
 crate-type = ["cdylib", "rlib"]
 
 [[bin]]
-name = "racket_rs"
+name = "scheme_rs"
 path = "src/main.rs"
 test = false

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Project settings
-PACKAGE_NAME = racket-rs
+PACKAGE_NAME = scheme-rs
 DOCS_DIR = docs
 PKG_DIR = $(DOCS_DIR)/pkg
 
@@ -18,6 +18,6 @@ build: build-bin build-web
 clean:
 	cargo clean
 	rm -rf $(PKG_DIR)
-	rm -f $(DOCS_DIR)/racket_rs*
+	rm -f $(DOCS_DIR)/scheme_rs*
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# racket-rs
+# scheme-rs
 
-A Rust-based Racket interpreter. Just a fun little project.
+A Rust-based Scheme interpreter. Just a fun little project.
 
 ## 🌐 Live Demo
 
 Try the playground in your browser:  
-https://mrbengutierrez.github.io/racket-rs/
+https://mrbengutierrez.github.io/scheme-rs/
 
 ## 🛠 Building
 
@@ -55,5 +55,5 @@ make clean
 ## ❌ Not Supported (yet)
 - Macros
 - Tail-call optimization
-- Full Racket standard library
+- Full Scheme standard library
 - Advanced types and I/O

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# racket-rs
+# scheme-rs
 
-A Rust-based Racket interpreter. Just a fun little project.
+A Rust-based Scheme interpreter. Just a fun little project.
 
 ## 🛠 Building
 
@@ -16,7 +16,7 @@ make clean
 ## 🌐 Live Demo
 
 Try the playground in your browser:  
-https://mrbengutierrez.github.io/racket-rs/
+https://mrbengutierrez.github.io/scheme-rs/
 
 
 ## ✅ Currently Supported
@@ -50,5 +50,5 @@ https://mrbengutierrez.github.io/racket-rs/
 ## ❌ Not Supported (yet)
 - Macros
 - Tail-call optimization
-- Full Racket standard library
+- Full Scheme standard library
 - Advanced types and I/O

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Racket-rs in the Browser</title>
+  <title>Scheme-rs in the Browser</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- Bootstrap 5 CDN -->
@@ -11,7 +11,7 @@
 <body class="bg-dark text-light p-4">
 
   <div class="container">
-    <h1 class="mb-4">🦀 Racket-rs Playground</h1>
+    <h1 class="mb-4">🦀 Scheme-rs Playground</h1>
 
     <div class="mb-3">
       <pre id="output" class="form-control bg-black text-success" style="height: 300px; overflow-y: auto;"></pre>

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,4 +1,4 @@
-import init, { EvalContext } from "./pkg/racket_rs.js";
+import init, { EvalContext } from "./pkg/scheme_rs.js";
 
 async function runWasm() {
     await init();
@@ -16,7 +16,7 @@ async function runWasm() {
             inputEl.value = "";
 
             const result = ctx.eval_line(line);
-            appendOutput(`racket-rs> ${line}`);
+            appendOutput(`scheme-rs> ${line}`);
             appendOutput(result);
 
             // If user typed "exit", disable further input
@@ -32,7 +32,7 @@ async function runWasm() {
         outputEl.scrollTop = outputEl.scrollHeight;
     }
 
-    appendOutput("🦀 Welcome to the Racket REPL (WASM Edition)");
+    appendOutput("🦀 Welcome to the Scheme REPL (WASM Edition)");
     appendOutput("💀 Type `exit` or `quit` when your existential dread sets in.");
     appendOutput("");
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "racket-rs",
+  "name": "scheme-rs",
   "type": "module",
   "version": "0.1.0",
   "files": [
-    "racket_rs_bg.wasm",
-    "racket_rs.js",
-    "racket_rs.d.ts"
+    "scheme_rs_bg.wasm",
+    "scheme_rs.js",
+    "scheme_rs.d.ts"
   ],
-  "main": "racket_rs.js",
-  "types": "racket_rs.d.ts",
+  "main": "scheme_rs.js",
+  "types": "scheme_rs.d.ts",
   "sideEffects": [
     "./snippets/*"
   ]

--- a/docs/pkg/README.md
+++ b/docs/pkg/README.md
@@ -1,11 +1,11 @@
-# racket-rs
+# scheme-rs
 
-A Rust-based Racket interpreter. Just a fun little project.
+A Rust-based Scheme interpreter. Just a fun little project.
 
 ## 🌐 Live Demo
 
 Try the playground in your browser:  
-https://mrbengutierrez.github.io/racket-rs/
+https://mrbengutierrez.github.io/scheme-rs/
 
 ## 🛠 Building
 
@@ -55,5 +55,5 @@ make clean
 ## ❌ Not Supported (yet)
 - Macros
 - Tail-call optimization
-- Full Racket standard library
+- Full Scheme standard library
 - Advanced types and I/O

--- a/docs/pkg/package.json
+++ b/docs/pkg/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "racket_rs",
+  "name": "scheme_rs",
   "type": "module",
   "version": "0.1.0",
   "files": [
-    "racket_rs_bg.wasm",
-    "racket_rs.js",
-    "racket_rs.d.ts"
+    "scheme_rs_bg.wasm",
+    "scheme_rs.js",
+    "scheme_rs.d.ts"
   ],
-  "main": "racket_rs.js",
-  "types": "racket_rs.d.ts",
+  "main": "scheme_rs.js",
+  "types": "scheme_rs.d.ts",
   "sideEffects": [
     "./snippets/*"
   ]

--- a/docs/pkg/racket_rs.js
+++ b/docs/pkg/racket_rs.js
@@ -222,7 +222,7 @@ async function __wbg_init(module_or_path) {
     }
 
     if (typeof module_or_path === 'undefined') {
-        module_or_path = new URL('racket_rs_bg.wasm', import.meta.url);
+        module_or_path = new URL('scheme_rs_bg.wasm', import.meta.url);
     }
     const imports = __wbg_get_imports();
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use crate::env::{Env, EvalError, Value, Lambda};
 use crate::ast::Expr;
 
-/// Evaluates a Racket expression in the given environment.
+/// Evaluates a Scheme expression in the given environment.
 ///
 /// Supports literals (number, boolean, string), variable lookup, and
 /// special forms: `define`, `lambda`, `begin`, `if`, and `let`.
@@ -11,7 +11,7 @@ use crate::ast::Expr;
 /// functions (lambdas).
 ///
 /// # Arguments
-/// * `expr` - The Racket expression to evaluate.
+/// * `expr` - The Scheme expression to evaluate.
 /// * `env` - The current lexical environment.
 ///
 /// # Returns

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -15,7 +15,7 @@ pub enum LexError {
     InvalidToken(String),
 }
 
-/// Tokenizes a Racket source string into a vector of `Token`s.
+/// Tokenizes a Scheme source string into a vector of `Token`s.
 /// 
 /// Parses the input string into tokens including parentheses, symbols,
 /// numbers, booleans, string literals, and skips comments and whitespace.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,20 @@
 use std::io::{self, Write};
 
-use racket_rs::env::default_env;
-use racket_rs::eval::eval;
-use racket_rs::lexer::tokenize;
-use racket_rs::parser::parse;
+use scheme_rs::env::default_env;
+use scheme_rs::eval::eval;
+use scheme_rs::lexer::tokenize;
+use scheme_rs::parser::parse;
 
 fn main() {
     let env = default_env(); // REPL uses a persistent environment
     let stdin = io::stdin();
     let mut stdout = io::stdout();
 
-    println!("🦀 Welcome to the Racket REPL (Rust Edition)");
+    println!("🦀 Welcome to the Scheme REPL (Rust Edition)");
     println!("💀 Type `exit` or `quit` when your existential dread sets in.");
 
     loop {
-        print!("racket-rs> ");
+        print!("scheme-rs> ");
         stdout.flush().unwrap();
 
         let mut input = String::new();


### PR DESCRIPTION
### 🌀 Refocused Project from Racket to Scheme 

This PR includes the following major changes:

- **Language Semantics Shift:**  
  While the project began as a **Racket-inspired interpreter written in Rust (racket-rs)**, it has evolved into a more minimal, standards-aligned **Scheme interpreter**. The rename and feature set now better reflect this direction — hence the transition to **scheme-rs**.